### PR TITLE
Basic rule engine supporting very basic use cases

### DIFF
--- a/sample_rules/simple0.yaml
+++ b/sample_rules/simple0.yaml
@@ -1,0 +1,9 @@
+- condition: transmission_gear == 'reverse'
+  emit:
+    signal: car.backup
+    value: true
+
+- condition: phone_call == 'active'
+  emit:
+    signal: car.stop
+    value: true

--- a/sample_rules/simple1.yaml
+++ b/sample_rules/simple1.yaml
@@ -1,0 +1,4 @@
+- condition: damage == true
+  emit:
+    signal: car.stop
+    value: true

--- a/sample_rules/simple2.initial.yaml
+++ b/sample_rules/simple2.initial.yaml
@@ -1,0 +1,1 @@
+- moving = false

--- a/sample_rules/simple2.yaml
+++ b/sample_rules/simple2.yaml
@@ -1,0 +1,4 @@
+- condition: moving != true && damage == true
+  emit:
+    signal: car.stop
+    value: true

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# Copyright (C) 2017 Collabora
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# Authors: Shane Fagan - shane.fagan@collabora.com
+
+import os
+import unittest
+from subprocess import Popen, PIPE
+
+
+RULES_PATH = os.path.abspath(os.path.join('.', 'sample_rules'))
+
+
+class TestVSM(unittest.TestCase):
+    def run_vsm(self, name, input_data, expected_output, use_initial=True):
+        conf = os.path.join(RULES_PATH, name + '.yaml')
+        initial_state = os.path.join(RULES_PATH, name + '.initial.yaml')
+
+        cmd = ['./vsm' ]
+
+        if use_initial and os.path.exists(initial_state):
+            cmd += ['--initial-state={}'.format(initial_state)]
+
+        cmd += [conf]
+
+        process = Popen(cmd, stdin=PIPE, stdout=PIPE)
+
+        output, _ = process.communicate(input=input_data.encode(), timeout=2)
+
+        self.assertEqual(output.decode() , expected_output)
+
+    def test_simple0(self):
+        input_data = 'transmission_gear = "reverse"'
+        expected_output = 'car.backup = True\n'
+        self.run_vsm('simple0', input_data, expected_output)
+
+    def test_simple0_uninteresting(self):
+        input_data = 'phone_call = "inactive"'
+        expected_output = ''
+        self.run_vsm('simple0', input_data, expected_output)
+
+    def test_simple2_initial(self):
+        input_data = 'damage = true'
+        expected_output = 'car.stop = True\n'
+        self.run_vsm('simple2', input_data, expected_output)
+
+    def test_simple2_initial_uninteresting(self):
+        input_data = 'moving = false'
+        expected_output = ''
+        self.run_vsm('simple2', input_data, expected_output)
+
+    def test_simple2_modify_uninteresting(self):
+        input_data = 'moving = true\ndamage = true'
+        expected_output = ''
+        self.run_vsm('simple2', input_data, expected_output)
+
+    def test_simple2_multiple_signals(self):
+        input_data = 'moving = false\ndamage = true'
+        expected_output = 'car.stop = True\n'
+        self.run_vsm('simple2', input_data, expected_output, False)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/vsm
+++ b/vsm
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2017, Jaguar Land Rover
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Authors:
+#  * Gustavo Noronha <gustavo.noronha@collabora.com>
+#  * Shane Fagan <shane.fagan@collabora.com>
+
+import sys
+import argparse
+import yaml
+import ast
+
+LOGIC_REPLACE = {'||': 'or',
+                 '&&': 'and',
+                 'true': 'True',
+                 'false': 'False'}
+
+KEYWORDS = ['condition', 'emit']
+
+class State(object):
+    '''
+        Class to handle states
+    '''
+    def __init__(self, initial_state, rules):
+        class VariablesStorage(object):
+            pass
+        self.variables = VariablesStorage()
+
+        self.rules = {}
+        with open(rules) as rules_file:
+            self.parse_rules(rules_file)
+
+        if initial_state:
+            with open(initial_state) as f:
+                data = yaml.load(f.read())
+
+                for item in data:
+                    item = item.replace(" ", "").split("=")
+                    vars(self.variables)[item[0]] = item[1]
+
+    def parse_rules(self, rules_file):
+        '''
+            Parse YAML rules for policy manager and return ast code.
+        '''
+        data = rules_file.read()
+
+        # Translate logical operations to Python, so that they
+        # can be compiled.
+        for key, value in LOGIC_REPLACE.items():
+             data = data.replace(key, value).strip()
+
+        data = yaml.load(data)
+
+        # Process rule logic and turn it into AST.
+        for block in data:
+            for word in block:
+                if word == "condition":
+                    condition = block[word]
+                    condition = ast.parse(condition).body[0]
+
+                elif word == "emit":
+                    signal = block[word]["signal"]
+                    value = block[word]["value"]
+                    action = "emit(\'{}\', \'{}\')".format(signal, value)
+                    action = ast.parse(action).body[0]
+
+                else:
+                    print("Unhandled keyword {}".format(word))
+
+            ifnode = ast.If(condition.value, [action], [])
+            ast_module = ast.Module([ifnode])
+
+            ast.fix_missing_locations(ast_module)
+
+            rule = compile(ast_module, '<string>', 'exec')
+            self.add_rule(condition, rule)
+
+    def add_rule(self, condition, rule):
+        tracked_signal = None
+
+        names = []
+        attributes = []
+        for node in ast.walk(condition):
+            if isinstance(node, ast.Attribute):
+                attributes.append(node.attr)
+            if isinstance(node, ast.Name):
+                name = node.id
+                if attributes:
+                    name = '.'.join(reversed(attributes + [name]))
+                    attributes = []
+                names.append(name)
+
+        for signal_name in names:
+            if not signal_name in self.rules:
+                self.rules[signal_name] = []
+            self.rules[signal_name].append(rule)
+
+    def got_signal(self, signal, value):
+        vars(self.variables)[signal] = value
+
+        # No conditions based on the signal that was emitted,
+        # nothing to be done.
+        if not signal in self.rules:
+            return
+
+        for rule in self.rules[signal]:
+            try:
+                exec(rule, globals(), vars(self.variables))
+            except NameError:
+                # Names used in rules are not always present
+                # in the state.
+                pass
+
+
+def emit(signal, value):
+    print('{} = {}'.format(signal, value))
+
+
+def process(state, signal, value):
+    '''
+        Handle the emitting of signals and adding values to state
+    '''
+    def is_string(value):
+        return (value[0] == '"' or value[0] == "'") and \
+            (value[-1] == '"' or value[-1] == "'")
+
+    def is_bool(value):
+        return value == 'true' or value == 'false'
+
+    # from str to int or float (if that is needed)
+    if is_string(value):
+        value = value[1:-1]
+    elif is_bool(value):
+        value = value == 'true' or False
+    else:
+        if value.isalnum():
+            if '.' in value:
+                value = float(value)
+            else:
+                value = int(value)
+
+    state.got_signal(signal, value)
+
+
+def run(state):
+    '''
+        Loop to grab logic from stdin, then spawn a threads for processing
+    '''
+    for line in sys.stdin:
+        line = line.replace(" ", "").strip('\n')
+        if line == "":
+            # Ignore blank lines
+            pass
+        if line == "quit":
+            break
+        elif "=" in line:
+            line = line.split("=")
+            process(state, line[0], line[1])
+        else:
+            process(state, line, None)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--initial-state', type=str,
+                        help='Initial state, yaml file', required=False)
+    parser.add_argument('rules', type=str,
+                        help='yaml rules configuration')
+    args = parser.parse_args()
+
+    state = State(args.initial_state, args.rules)
+    run(state)


### PR DESCRIPTION
It receives signals through standard input and 'emits' signals through
standard output. Rules are compiled to python bytecode that can be quickly
executed when a signal arrives.

This should work as a baseline for understanding the problem space a bit
better and building more complex use cases.

Based on an initial version by Shane Fagan <shane.fagan@collabora.com>