### PR TITLE
Dot notation support

### DIFF
--- a/sample_rules/simple3.yaml
+++ b/sample_rules/simple3.yaml
@@ -1,4 +1,4 @@
-- condition: phone_call == 'active' ^^ speed > 50
+- condition: phone.call == 'active' ^^ speed.value > 50.90
   emit:
     signal: car.stop
     value: true

--- a/tests.py
+++ b/tests.py
@@ -267,21 +267,21 @@ car.stop,[SIGNUM],'True'
                 replay_case='simple0-replay', wait_time_ms=5000)
 
     def test_simple3_xor_condition(self):
-        input_data = 'phone_call = "active"\nspeed = 5'
+        input_data = 'phone.call = "active"\nspeed.value = 5.0'
         expected_output = '''
-phone_call,[SIGNUM],'active'
+phone.call,[SIGNUM],'active'
 State = {
-phone_call = active
+phone.call = active
 }
-speed,[SIGNUM],5
+speed.value,[SIGNUM],5.0
 State = {
-phone_call = active
-speed = 5
+phone.call = active
+speed.value = 5.0
 }
 car.stop,[SIGNUM],'True'
-condition: ((phone_call == 'active') != (speed > 50)) => True
-phone_call,[SIGNUM],'"active"'
-speed,[SIGNUM],'5'
+condition: (phone.call == 'active' ^^ speed.value > 50.90) => True
+phone.call,[SIGNUM],'"active"'
+speed.value,[SIGNUM],'5.0'
 car.stop,[SIGNUM],'True'
         '''
         self.run_vsm('simple3', input_data, expected_output.strip() + '\n')

--- a/vsm
+++ b/vsm
@@ -221,21 +221,10 @@ class State(object):
                 self.__parse_items(item)
 
     def add_rule(self, condition, rule):
-        tracked_signal = None
+        parser = ParseIdentifiers()
+        parser.visit(condition)
 
-        names = []
-        attributes = []
-        for node in ast.walk(condition):
-            if isinstance(node, ast.Attribute):
-                attributes.append(node.attr)
-            if isinstance(node, ast.Name):
-                name = node.id
-                if attributes:
-                    name = '.'.join(reversed(attributes + [name]))
-                    attributes = []
-                names.append(name)
-
-        for signal_name in names:
+        for signal_name in parser.identifiers:
             if not signal_name in self.rules:
                 self.rules[signal_name] = []
             self.rules[signal_name].append(rule)
@@ -266,6 +255,33 @@ class State(object):
         for k, v in sorted(vars(self.variables).items()):
             logger.i("{} = {}".format(k, v))
         logger.i("}")
+
+class ParseIdentifiers(ast.NodeVisitor):
+    '''
+        Class to parse identifiers (signals and attributes names)
+    '''
+
+    def __init__(self):
+        self.identifiers = []
+        self._attributes = []
+
+    def visit_Name(self, node):
+        def make_identifier(node_id):
+            return '.'.join(reversed(self._attributes + [node.id]))
+
+        if self._attributes:
+            # If a name is found with attributes available, build the identifier
+            # and reset the attributes list.
+            self.identifiers.append(make_identifier(node.id))
+            self._attributes = []
+        else:
+            self.identifiers.append(node.id)
+
+        super().generic_visit(node)
+
+    def visit_Attribute(self, node):
+        self._attributes.append(node.attr)
+        super().generic_visit(node)
 
 class LogReplayer(object):
     '''

--- a/vsm
+++ b/vsm
@@ -162,35 +162,45 @@ class State(object):
             exec(rule)
 
     def handle_condition(self, data):
+        orig_condition = data["condition"]
         # Handle XOR operator (if it is found)
-        if data["condition"].find('^^') >= 0:
-            condition = _handle_xor_condition(data["condition"])
+        if orig_condition.find('^^') >= 0:
+            condition = _handle_xor_condition(orig_condition)
         else:
-            condition = data["condition"]
+            condition = orig_condition
 
         condition_expr = ast.parse(condition).body[0]
+
+        # Parse identifiers (variables).
+        parser = ParseIdentifiers()
+        parser.visit(condition_expr)
+
+        # Replace dot (.) by underscore (_) in the condition identifiers so they
+        # can be correctly interpreted like Python variables.
+        eval_condition = self._undot_identifiers(condition, parser.identifiers)
+        eval_condition_expr = ast.parse(eval_condition).body[0]
 
         action_true_1_body = self.handle_emit(data, True)
         actions_true = [action_true_1_body]
         actions_false = []
 
         if self.log_categories[LOG_CAT_CONDITION_CHECKS]:
-            action_true_2_code = self.generate_condition_code(condition, True)
+            action_true_2_code = self.generate_condition_code(orig_condition, True)
             action_true_2 = ast.parse(action_true_2_code)
 
-            action_false_code = self.generate_condition_code(condition, False)
+            action_false_code = self.generate_condition_code(orig_condition, False)
             action_false = ast.parse(action_false_code)
 
             actions_true.append(action_true_2.body[0])
             actions_false.append(action_false.body[0])
 
-        ifnode = ast.If(condition_expr.value, actions_true, actions_false)
+        ifnode = ast.If(eval_condition_expr.value, actions_true, actions_false)
         ast_module = ast.Module([ifnode])
 
         ast.fix_missing_locations(ast_module)
 
         rule = compile(ast_module, '<string>', 'exec')
-        self.add_rule(condition_expr, rule)
+        self.add_rule(parser.identifiers, rule)
 
     def generate_condition_code(self, condition, result):
         return "logger.i(\"condition: ({}) => {}\")".format(condition,
@@ -220,11 +230,8 @@ class State(object):
             for item in data:
                 self.__parse_items(item)
 
-    def add_rule(self, condition, rule):
-        parser = ParseIdentifiers()
-        parser.visit(condition)
-
-        for signal_name in parser.identifiers:
+    def add_rule(self, identifiers, rule):
+        for signal_name in identifiers:
             if not signal_name in self.rules:
                 self.rules[signal_name] = []
             self.rules[signal_name].append(rule)
@@ -239,7 +246,7 @@ class State(object):
 
         for rule in self.rules[signal]:
             try:
-                exec(rule, globals(), vars(self.variables))
+                exec(rule, globals(), self._undot_variables(vars(self.variables)))
             except NameError:
                 # Names used in rules are not always present
                 # in the state.
@@ -255,6 +262,17 @@ class State(object):
         for k, v in sorted(vars(self.variables).items()):
             logger.i("{} = {}".format(k, v))
         logger.i("}")
+
+    def _undot_identifiers(self, condition, identifiers):
+        for ident in identifiers:
+            # Replace '.' by '_' in identifiers.
+            if ident.find('.') >= 0:
+                condition = condition.replace(ident, ident.replace('.', '_'))
+        return condition
+
+    def _undot_variables(self, variables):
+        # Replace '.' by '_' in variables names (identifiers)
+        return { k.replace('.', '_'): v for k, v in variables.items() }
 
 class ParseIdentifiers(ast.NodeVisitor):
     '''


### PR DESCRIPTION
Allow identifiers (signals, attibutes) to have dot notation
(use '.') in their names since this required by the Vehicle
Signal Specification.
    
This commit also changes the simple3.yaml rules file to test dot
notation and floating point values.
    
This change will also show the original conditions in the logs