### PR TITLE
Allow conditions blocks without emit instruction

### DIFF
--- a/sample_rules/monitored_condition.yaml
+++ b/sample_rules/monitored_condition.yaml
@@ -33,7 +33,3 @@
       # after the monitor is started. If those criteria are not fulfilled,
       # an error will be logged
       stop: 1000
-
-      emit:
-        signal: camera.backup.activated
-        value: true

--- a/tests.py
+++ b/tests.py
@@ -319,14 +319,12 @@ State = {
 camera.backup.active = True
 transmission.gear = reverse
 }
-camera.backup.activated,[SIGNUM],'True'
 condition: (camera.backup.active == True) => True
 transmission.gear,[SIGNUM],'reverse'
 transmission.gear,[SIGNUM],'"forward"'
 transmission.gear,[SIGNUM],'"reverse"'
 lights.external.backup,[SIGNUM],'True'
 camera.backup.active,[SIGNUM],'true'
-camera.backup.activated,[SIGNUM],'True'
         '''
         self.run_vsm('monitored_condition', input_data,
                 expected_output.strip() + '\n', wait_time_ms=1500)

--- a/vsm
+++ b/vsm
@@ -215,9 +215,12 @@ class State(object):
                 start=start_time_ms, stop=stop_time_ms)
         parent.add_child(condition_node)
 
-        action_true_1_module = self.handle_emit(data, parent)
-        action_true_1_body = action_true_1_module.body[0]
-        actions_true = [action_true_1_body]
+        if NODE_EMIT in data:
+            action_true_1_module = self.handle_emit(data, parent)
+            action_true_1_body = action_true_1_module.body[0]
+            actions_true = [action_true_1_body]
+        else:
+            actions_true = []
         actions_false = []
 
         if self.log_categories[LOG_CAT_CONDITION_CHECKS]:


### PR DESCRIPTION
In some of the YAML files these conditions are meaningful, for example,
they can contain a start or stop keyword to cause a monitored condition.

Signed-off-by: Luis Araujo <luis.araujo@collabora.co.uk>