### PR TITLE
J1030 Add Stream IPC classes

### DIFF
--- a/ipc/stream.py
+++ b/ipc/stream.py
@@ -1,0 +1,83 @@
+# Copyright (C) 2018 Collabora Limited
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Authors:
+#  * Guillaume Tucker <guillaume.tucker@collabora.com>
+
+import ipc
+import socket
+import sys
+
+
+class StreamIPC(ipc.FilenoIPC):
+    """IPC module based on a generic communication stream.
+
+    This class is to keep a pair of streams, for input and output, and
+    implement a basic text-based API in the format `signal=value\n`.
+    """
+
+    def __init__(self, input_stream, output_stream):
+        self._in = input_stream
+        self._out = output_stream
+
+    def close(self):
+        close(self._in)
+        close(self._out)
+
+    def fileno(self):
+        return self._in.fileno()
+
+    def send(self, signal, value):
+        self._write('{}={}\n'.format(signal, value))
+
+    def receive(self):
+        line = self._readline()
+        if line is None:
+            return None
+        return tuple(s.strip() for s in line.split('='))
+
+    def _write(self, data):
+        """Write some text data to emit a signal."""
+        self._out.write(data)
+        self._out.flush()
+
+    def _readline(self):
+        """Return one line from the input stream or None if EOF."""
+        line = ''
+        while not line:
+            line = self._in.readline() or None
+            if line is None:
+                break
+            line = line.strip()
+        return line
+
+
+class StdioIPC(StreamIPC):
+    """Stream IPC class based on stdin and stdout."""
+
+    def __init__(self, *args, **kwargs):
+        super(StdioIPC, self).__init__(sys.stdin, sys.stdout, *args, **kwargs)
+
+
+class SocketIPC(StreamIPC):
+    """Stream IPC class based on a TCP client connection to a server
+
+    This class will first open a client connection to a server specified by the
+    given host and port.  It will then use it for both input and output streams
+    using regular file interface functions.
+    """
+
+    def __init__(self, host, port, *args, **kwargs):
+        self._sock = socket.create_connection((host, port))
+        self._file = self._sock.makefile('rw')
+        super(SocketIPC, self).__init__(self._file, self._file, *args, **kwargs)
+
+    def close(self):
+        self._file.close()
+        self._sock.close()
+
+    def fileno(self):
+        return self._sock.fileno()

--- a/vsm
+++ b/vsm
@@ -19,7 +19,7 @@ import ast
 import threading
 import time
 import json
-import ipc
+import ipc.stream
 import os
 import uuid
 import vsmlib.utils
@@ -829,32 +829,23 @@ def show(signal, value, indicator):
     print(_format_signal_msg(signal, value, indicator))
 
 
-class StdioIPC(ipc.IPC):
-
-    def fileno(self):
-        return sys.stdin.fileno()
+class DebugIPC(ipc.stream.StdioIPC):
 
     def send(self, signal, value):
         show(signal, value, SIGNAL_PREFIX_OUTGOING)
 
     def receive(self):
-        '''
-            Loop to grab logic from stdin
-        '''
-        for line in sys.stdin:
-            line = line.replace(" ", "").strip('\n')
-            if line == "":
-                # Ignore blank lines
-                continue
-            if line == "quit":
-                exit(0)
-            elif "=" in line:
-                line = line.split("=")
-                show(line[0], line[1], SIGNAL_PREFIX_INCOMING)
-                return (line[0], line[1])
-            else:
-                show(line, None, SIGNAL_PREFIX_INCOMING)
-                return (line, None)
+        message = super(DebugIPC, self).receive()
+        if message is not None:
+            signal, value = message
+            show(signal, value, SIGNAL_PREFIX_INCOMING)
+        return message
+
+    def _readline(self):
+        line = super(DebugIPC, self)._readline()
+        if line == "quit":
+            exit(0)
+        return line
 
 
 # this includes an unused state parameter so it matches the signature of
@@ -1011,7 +1002,7 @@ if __name__ == "__main__":
             logger = Logger(pipeout_fd)
 
         if not args.ipc_modules:
-            ipc_obj = StdioIPC()
+            ipc_obj = DebugIPC()
         elif len(args.ipc_modules) == 1:
             ipc_obj = ipc.load(args.ipc_modules[0])
         else:


### PR DESCRIPTION
Based on the stdin / stdout IPC class, this is to create more generic stream IPC classes using any arbitrary file or network connection.

* Add `ipc.stream.StreamIPC` as base class for text-based stream IPC.
* Add `ipc.stream.StdioIPC` as an implementation with stdin and stdout.
* Add `ipc.stream.SocketIPC` to use network connection sockets.
* Convert `vsm.StdioIPC` to use `ipc.stream.StdioIPC` and rename it to `vsm.DebugIPC`.

The unit tests in `tests.py` are passing with these changes.