### PR TITLE
J1032 vsm: do not abort when signal is None

### DIFF
--- a/vsm
+++ b/vsm
@@ -927,8 +927,9 @@ def run(state):
     try:
         while True:
             message = ipc_obj.receive()
-            if message == None:
-                exit(0)
+            if message is None:
+                logger.i("skipping invalid message")
+                continue
 
             signal, value = message
             # 'quit' signal to close VSM endpoint.


### PR DESCRIPTION
When an IPC module receives a signal it doesn't know how to decode, it
should ignore it and its receive() method should return None.  When
this happens, skip the unknown signal in the VSM main loop.  If it
should have been decoded and passed to the VSM but failed, the
relevant IPC module can decide to raise an exception to actually
abort.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>