### PR TITLE
J1032 - Fix how IPC modules get closed

### DIFF
--- a/ipc/stream.py
+++ b/ipc/stream.py
@@ -24,8 +24,8 @@ class StreamIPC(ipc.FilenoIPC):
         self._out = output_stream
 
     def close(self):
-        close(self._in)
-        close(self._out)
+        self._in.close()
+        self._out.close()
 
     def fileno(self):
         return self._in.fileno()

--- a/ipc/stream.py
+++ b/ipc/stream.py
@@ -61,6 +61,9 @@ class StdioIPC(StreamIPC):
     def __init__(self, *args, **kwargs):
         super(StdioIPC, self).__init__(sys.stdin, sys.stdout, *args, **kwargs)
 
+    def receive(self):
+        return super(StdioIPC, self).receive() or ('quit', None)
+
 
 class SocketIPC(StreamIPC):
     """Stream IPC class based on a TCP client connection to a server

--- a/vsm
+++ b/vsm
@@ -933,7 +933,7 @@ def run(state):
             signal, value = message
             # 'quit' signal to close VSM endpoint.
             if signal == 'quit':
-                ipc_obj.send('', '')
+                ipc_obj.close()
                 break
 
             process(state, signal, value)


### PR DESCRIPTION
This is to fix a couple of things related to closing IPC modules:

* fix code in `ipc.stream.StreamIPC.close()`
* call `ipc_obj.close()` when the VSM main loop exits, rather than sending a `('', '')` empty signal
* return a `('quit', None)` signal in `ipc.stream.StdioIPC` instead of `None` upon EOF (see #44)