### PR TITLE
J1205 import vsm

### DIFF
--- a/ipc/__init__.py
+++ b/ipc/__init__.py
@@ -76,26 +76,25 @@ class FilenoIPC(IPC):
 class IPCList(IPC):
     """List of multiple IPC modules to use in parallel.
 
-    This will instanciate a list of class names and use them as a list of IPC
-    modules.  Each signal that the VSM needs to send will be sent through all
-    the modules.  Likewise, a signal received from any module will be used by
-    the VSM.  Each module that needs to be able to receive signals must
-    implement the FilenoIPC interface (essentially the fileno() method) for
-    this purpose.  Modules without this method will only be able to send
-    signals, not receive any.
+    This class manages a list of IPC modules.  Each signal that the VSM needs
+    to send will be sent through all the modules.  Likewise, a signal received
+    from any module will be used by the VSM.  Each module that needs to be able
+    to receive signals must implement the FilenoIPC interface (essentially the
+    fileno() method) for this purpose.  Modules without this method will only
+    be able to send signals, not receive any.
     """
 
-    def __init__(self, names):
-        self._list = list(load(name) for name in names)
-        self._inputs = list(i for i in self._list if hasattr(i, 'fileno'))
+    def __init__(self, modules):
+        self._modules = modules
+        self._inputs = list(i for i in self._modules if hasattr(i, 'fileno'))
         self._read = list()
 
     def close(self):
-        for i in self._list:
+        for i in self._modules:
             i.close()
 
     def send(self, *args, **kw):
-        for i in self._list:
+        for i in self._modules:
             i.send(*args, **kw)
 
     def receive(self, *args, **kw):

--- a/tests.py
+++ b/tests.py
@@ -186,7 +186,7 @@ class TestVSM(unittest.TestCase):
         conf = os.path.join(RULES_PATH, name + '.yaml')
         initial_state = os.path.join(RULES_PATH, name + '.initial.yaml')
 
-        cmd = ['./vsm' ]
+        cmd = ['/usr/bin/env', 'python3', 'vsm.py']
 
         sig_num_path = os.path.join(SIGNAL_NUMBER_PATH, SIGNAL_NUM_FILE)
         cmd += [ '--signal-number-file={}'.format(sig_num_path) ]

--- a/vsm.py
+++ b/vsm.py
@@ -978,7 +978,8 @@ def init_ipc(args):
     elif len(args.ipc_modules) == 1:
         ipc_obj = ipc.load(args.ipc_modules[0])
     else:
-        ipc_obj = ipc.IPCList(args.ipc_modules)
+        modules = list(ipc.load(name) for name in args.ipc_modules)
+        ipc_obj = ipc.IPCList(modules)
 
 
 def start_state_machine(args):

--- a/vsm.py
+++ b/vsm.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python3
-#
-# Copyright (C) 2017, Jaguar Land Rover
+# Copyright (C) 2017, 2018 Jaguar Land Rover
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this


### PR DESCRIPTION
This is to be able to `import vsm` and use it in a separate module to add more specific code.  It is useful in particular to create an arbitrary list of IPC modules with more flexibility than what the standard VSM command line options can provide.